### PR TITLE
Adding header support

### DIFF
--- a/Source/HTTPFile.swift
+++ b/Source/HTTPFile.swift
@@ -27,9 +27,10 @@
 
 public struct FileResponder: Responder {
     let path: String
-
-    public init(path: String) {
+    let headers : Headers
+    public init(path: String, headers: Headers = [:]) {
         self.path = path
+        self.headers = headers
     }
 
     public func respond(to request: Request) throws -> Response {
@@ -46,8 +47,7 @@ public struct FileResponder: Responder {
         if path.ends(with: "/") {
             path += "index.html"
         }
-
-        return Response(status: .ok, filePath: self.path + path)
+        return Response(status: .ok, headers: headers, filePath: self.path + path)
     }
 }
 


### PR DESCRIPTION
Currently HTTPFile Ignores Header information. This able to set custom header for response, so web browser can cache it and makes web display faster.

sample (cache 7 days this is example, and formatting date is not include in HTTPFile)

```
let fileResponder = FileResponder(path: ImworkingConfig.Server.fileBasePath, headers: ["Cache-Control":"max-age=604800","Expires": Header([try NSDate().addingTimeInterval((24*7).hours).getTimeStrFrom(format:"EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz")])])
```

it defaults [:] so this PR doesn't affect any of current behavior.
